### PR TITLE
Add firefox-crash-dialog.xml test case.

### DIFF
--- a/recompose-test/src/main/resources/firefox-crash-dialog.xml
+++ b/recompose-test/src/main/resources/firefox-crash-dialog.xml
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  This is a modified version of fragment_crash_reporter.xml of Firefox for Android. Text, color and drawable resources
+  have been replaced with inline values. Other than that the layout was left as-is to have a real world test case.
+  https://github.com/mozilla-mobile/fenix/blob/master/app/src/main/res/layout/fragment_crash_reporter.xml
+-->
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="#ffff00">
+
+    <ImageView
+        android:id="@+id/crash_tab_image"
+        android:layout_width="0dp"
+        android:layout_height="120dp"
+        android:layout_marginTop="40dp"
+        android:importantForAccessibility="no"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintWidth_percent="0.8"
+        app:srcCompat="@android:drawable/ic_lock_power_off" />
+
+    <TextView
+        android:id="@+id/title"
+        android:layout_width="300dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="6dp"
+        android:lineSpacingExtra="8sp"
+        android:singleLine="false"
+        android:textColor="#ff000000"
+        android:textSize="24sp"
+        android:textStyle="bold"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/crash_tab_image"
+        tools:text="Sorry, this doesn't work." />
+
+    <CheckBox
+        android:id="@+id/sendCrashCheckbox"
+        android:layout_width="0dp"
+        android:layout_height="48dp"
+        android:paddingTop="6dp"
+        android:paddingBottom="6dp"
+        android:layout_marginBottom="8dp"
+        android:buttonTint="#ffcc00"
+        android:checked="true"
+        android:text="Let someone know about this."
+        android:textColor="#ff000000"
+        android:textSize="15sp"
+        app:layout_constraintBottom_toTopOf="@id/closeTabButton"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintWidth_percent="0.9" />
+
+    <Button
+        android:id="@+id/restoreTabButton"
+        android:layout_width="0dp"
+        android:layout_height="48dp"
+        android:layout_marginStart="8dp"
+        android:layout_marginEnd="8dp"
+        android:layout_marginBottom="8dp"
+        android:fontFamily="Sharp Sans"
+        android:text="Restore"
+        android:textAllCaps="false"
+        android:textColor="#ffcc00"
+        android:textSize="14sp"
+        android:textStyle="bold"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintWidth_percent="0.4" />
+
+    <Button
+        android:id="@+id/closeTabButton"
+        android:layout_width="0dp"
+        android:layout_height="48dp"
+        android:layout_marginStart="8dp"
+        android:layout_marginEnd="8dp"
+        android:layout_marginBottom="8dp"
+        android:fontFamily="Sharp Sans"
+        android:text="Close"
+        android:textAllCaps="false"
+        android:textColor="#ffcc00"
+        android:textSize="14sp"
+        android:textStyle="bold"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintWidth_percent="0.4" />
+</androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
A real world example copied over from Firefox for Android.

It's not used in a test yet. I'll collect issues that need to be fixed in order to make
a test with it pass in the following milestone:
https://github.com/pocmo/recompose/milestone/2