### PR TITLE
Update ParameterValue.kt to fix a typo

### DIFF
--- a/recompose-composer/src/main/kotlin/recompose/composer/writer/ParameterValue.kt
+++ b/recompose-composer/src/main/kotlin/recompose/composer/writer/ParameterValue.kt
@@ -36,7 +36,7 @@ internal sealed class ParameterValue {
 
     object EmptyLambdaValue : ParameterValue()
 
-    class ColoValue(
+    class ColorValue(
         val color: Color
     ) : ParameterValue()
 


### PR DESCRIPTION
Fixed the typo 'ColoValue' to 'ColorValue' as mentioned in the #78