### PR TITLE
#96 Add support for MaterialCardView

### DIFF
--- a/recompose-parser/src/main/kotlin/recompose/parser/xml/View.kt
+++ b/recompose-parser/src/main/kotlin/recompose/parser/xml/View.kt
@@ -59,7 +59,8 @@ internal fun XmlPullParser.node(): Node {
 
         // AndroidX
         "androidx.constraintlayout.widget.ConstraintLayout" -> constraintLayout()
-        "androidx.cardview.widget.CardView" -> cardView()
+        "androidx.cardview.widget.CardView",
+        "com.google.android.material.card.MaterialCardView" -> cardView()
 
         else -> unknown()
     }

--- a/recompose-parser/src/test/kotlin/recompose/parser/ParserTest.kt
+++ b/recompose-parser/src/test/kotlin/recompose/parser/ParserTest.kt
@@ -386,66 +386,66 @@ class ParserTest {
     @Test
     fun `Simple MaterialCardView`() {
         assertAST(
-                fileName = "material-cardview.xml",
-                Layout(
-                        children = listOf(
-                                CardViewNode(
-                                        view = ViewAttributes(
-                                                id = "card",
-                                                width = LayoutSize.Absolute(Size.Dp(300)),
-                                                height = LayoutSize.Absolute(Size.Dp(100)),
-                                        )
-                                )
+            fileName = "material-cardview.xml",
+            Layout(
+                children = listOf(
+                    CardViewNode(
+                        view = ViewAttributes(
+                            id = "card",
+                            width = LayoutSize.Absolute(Size.Dp(300)),
+                            height = LayoutSize.Absolute(Size.Dp(100)),
                         )
+                    )
                 )
+            )
         )
     }
 
     @Test
     fun `MaterialCardView with TextView and Button`() {
         assertAST(
-                fileName = "material-cardview-textview-button.xml",
-                expected = Layout(
-                        children = listOf(
-                                CardViewNode(
-                                        view = ViewAttributes(
-                                                id = "card",
-                                                width = LayoutSize.Absolute(Size.Dp(300)),
-                                                height = LayoutSize.Absolute(Size.Dp(100)),
-                                        ),
-                                        viewGroup = ViewGroupAttributes(
-                                                children = listOf(
-                                                        LinearLayoutNode(
-                                                                ViewAttributes(
-                                                                        width = LayoutSize.MatchParent,
-                                                                        height = LayoutSize.MatchParent
-                                                                ),
-                                                                ViewGroupAttributes(
-                                                                        listOf(
-                                                                                TextViewNode(
-                                                                                        ViewAttributes(
-                                                                                                width = LayoutSize.WrapContent,
-                                                                                                height = LayoutSize.WrapContent
-                                                                                        ),
-                                                                                        text = "Hello World!",
-                                                                                        textColor = Color.Absolute(0xFFFF0000)
-                                                                                ),
-                                                                                ButtonNode(
-                                                                                        ViewAttributes(
-                                                                                                width = LayoutSize.WrapContent,
-                                                                                                height = LayoutSize.WrapContent
-                                                                                        ),
-                                                                                        text = "Click me!"
-                                                                                )
-                                                                        )
-                                                                ),
-                                                                Orientation.Vertical
-                                                        )
-                                                )
+            fileName = "material-cardview-textview-button.xml",
+            expected = Layout(
+                children = listOf(
+                    CardViewNode(
+                        view = ViewAttributes(
+                            id = "card",
+                            width = LayoutSize.Absolute(Size.Dp(300)),
+                            height = LayoutSize.Absolute(Size.Dp(100)),
+                        ),
+                        viewGroup = ViewGroupAttributes(
+                            children = listOf(
+                                LinearLayoutNode(
+                                    ViewAttributes(
+                                        width = LayoutSize.MatchParent,
+                                        height = LayoutSize.MatchParent
+                                    ),
+                                    ViewGroupAttributes(
+                                        listOf(
+                                            TextViewNode(
+                                                ViewAttributes(
+                                                    width = LayoutSize.WrapContent,
+                                                    height = LayoutSize.WrapContent
+                                                ),
+                                                text = "Hello World!",
+                                                textColor = Color.Absolute(0xFFFF0000)
+                                            ),
+                                            ButtonNode(
+                                                ViewAttributes(
+                                                    width = LayoutSize.WrapContent,
+                                                    height = LayoutSize.WrapContent
+                                                ),
+                                                text = "Click me!"
+                                            )
                                         )
+                                    ),
+                                    Orientation.Vertical
                                 )
+                            )
                         )
+                    )
                 )
+            )
         )
     }
 

--- a/recompose-parser/src/test/kotlin/recompose/parser/ParserTest.kt
+++ b/recompose-parser/src/test/kotlin/recompose/parser/ParserTest.kt
@@ -384,6 +384,72 @@ class ParserTest {
     }
 
     @Test
+    fun `Simple MaterialCardView`() {
+        assertAST(
+                fileName = "material-cardview.xml",
+                Layout(
+                        children = listOf(
+                                CardViewNode(
+                                        view = ViewAttributes(
+                                                id = "card",
+                                                width = LayoutSize.Absolute(Size.Dp(300)),
+                                                height = LayoutSize.Absolute(Size.Dp(100)),
+                                        )
+                                )
+                        )
+                )
+        )
+    }
+
+    @Test
+    fun `MaterialCardView with TextView and Button`() {
+        assertAST(
+                fileName = "material-cardview-textview-button.xml",
+                expected = Layout(
+                        children = listOf(
+                                CardViewNode(
+                                        view = ViewAttributes(
+                                                id = "card",
+                                                width = LayoutSize.Absolute(Size.Dp(300)),
+                                                height = LayoutSize.Absolute(Size.Dp(100)),
+                                        ),
+                                        viewGroup = ViewGroupAttributes(
+                                                children = listOf(
+                                                        LinearLayoutNode(
+                                                                ViewAttributes(
+                                                                        width = LayoutSize.MatchParent,
+                                                                        height = LayoutSize.MatchParent
+                                                                ),
+                                                                ViewGroupAttributes(
+                                                                        listOf(
+                                                                                TextViewNode(
+                                                                                        ViewAttributes(
+                                                                                                width = LayoutSize.WrapContent,
+                                                                                                height = LayoutSize.WrapContent
+                                                                                        ),
+                                                                                        text = "Hello World!",
+                                                                                        textColor = Color.Absolute(0xFFFF0000)
+                                                                                ),
+                                                                                ButtonNode(
+                                                                                        ViewAttributes(
+                                                                                                width = LayoutSize.WrapContent,
+                                                                                                height = LayoutSize.WrapContent
+                                                                                        ),
+                                                                                        text = "Click me!"
+                                                                                )
+                                                                        )
+                                                                ),
+                                                                Orientation.Vertical
+                                                        )
+                                                )
+                                        )
+                                )
+                        )
+                )
+        )
+    }
+
+    @Test
     fun `Basic Checkbox`() {
         assertAST(
             "checkbox.xml",

--- a/recompose-test/src/main/resources/material-cardview-textview-button.xml
+++ b/recompose-test/src/main/resources/material-cardview-textview-button.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.google.android.material.card.MaterialCardView
+        xmlns:android="http://schemas.android.com/apk/res/android"
+        xmlns:app="http://schemas.android.com/apk/res-auto"
+        android:id="@+id/card"
+        android:layout_width="300dp"
+        android:layout_height="100dp" >
+    <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:orientation="vertical">
+
+        <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:textColor="#ff0000"
+                android:text="Hello World!"/>
+
+        <Button
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Click me!"/>
+
+    </LinearLayout>
+</com.google.android.material.card.MaterialCardView>

--- a/recompose-test/src/main/resources/material-cardview.xml
+++ b/recompose-test/src/main/resources/material-cardview.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.google.android.material.card.MaterialCardView
+        xmlns:android="http://schemas.android.com/apk/res/android"
+        xmlns:app="http://schemas.android.com/apk/res-auto"
+        android:id="@+id/card"
+        android:layout_width="300dp"
+        android:layout_height="100dp" />


### PR DESCRIPTION
Issue: https://github.com/pocmo/recompose/issues/96 Add support for MaterialCardView

### Context

`com.google.android.material.card.MaterialCardView` extends `androidx.cardview.widget.CardView` and could use the same parser.

View available in:
```
com.google.android.material:material:1.2.1
```

### Changes

`CardView` and `MaterialCardView` use the same parser: `cardView()`

```kotlin
internal fun XmlPullParser.node(): Node {
    require(START_TAG, null, null)

    return when (name) {

		// ...

        "androidx.cardview.widget.CardView",  
        "com.google.android.material.card.MaterialCardView" -> cardView()

		// ...
     }
}

```