### PR TITLE
#98 Add support for style attribute

### DIFF
--- a/recompose-ast/src/main/kotlin/recompose/ast/values/Drawable.kt
+++ b/recompose-ast/src/main/kotlin/recompose/ast/values/Drawable.kt
@@ -34,4 +34,9 @@ sealed class Drawable {
      * An Android resource reference drawable, e.g. @android:drawable/an_image.
      */
     data class AndroidResource(val name: String) : Drawable()
+
+    /**
+     * An Android style attribute, e.g. ?my_image or ?attr/my_image.
+     */
+    data class StyleAttribute(val name: String) : Drawable()
 }

--- a/recompose-composer/src/main/kotlin/recompose/composer/writer/KotlinWriter.kt
+++ b/recompose-composer/src/main/kotlin/recompose/composer/writer/KotlinWriter.kt
@@ -225,6 +225,15 @@ internal class KotlinWriter {
                     endLine = false
                 )
             }
+            is Drawable.StyleAttribute -> {
+                writeCall(
+                    name = "imageAttribute",
+                    parameters = listOf(
+                        CallParameter(ParameterValue.RawValue(value.drawable.name))
+                    ),
+                    endLine = false
+                )
+            }
         }
     }
 

--- a/recompose-composer/src/test/kotlin/recompose/composer/ComposerTest.kt
+++ b/recompose-composer/src/test/kotlin/recompose/composer/ComposerTest.kt
@@ -315,4 +315,14 @@ class ComposerTest {
             """.trimIndent()
         )
     }
+
+    @Test
+    fun `Basic Style Attributes`() {
+        assertComposing(
+            fileName = "styleattributes.xml",
+            """
+                Text(text = "", modifier = Modifier.width(200.dp).height(50.dp).background(imageAttribute(selectableItemBackground)))
+            """.trimIndent()
+        )
+    }
 }

--- a/recompose-parser/src/main/kotlin/recompose/parser/values/Drawable.kt
+++ b/recompose-parser/src/main/kotlin/recompose/parser/values/Drawable.kt
@@ -36,6 +36,8 @@ fun XmlPullParser.drawable(name: String): Drawable? {
 
         value.startsWith("@android:drawable/") -> Drawable.AndroidResource(name = value.substring(18))
 
+        value.startsWith("?") -> Drawable.StyleAttribute(name = value.substring(1))
+
         else -> throw Parser.ParserException("Unknown drawable format: $value")
     }
 }

--- a/recompose-parser/src/test/kotlin/recompose/parser/ParserTest.kt
+++ b/recompose-parser/src/test/kotlin/recompose/parser/ParserTest.kt
@@ -457,4 +457,23 @@ class ParserTest {
             )
         )
     }
+
+    @Test
+    fun `Basic Style Attributes`() {
+        assertAST(
+            "styleattributes.xml",
+            Layout(
+                listOf(
+                    TextViewNode(
+                        view = ViewAttributes(
+                            width = LayoutSize.Absolute(Size.Dp(200)),
+                            height = LayoutSize.Absolute(Size.Dp(50)),
+                            background = Drawable.StyleAttribute("selectableItemBackground")
+                        ),
+                        text = "",
+                    )
+                )
+            )
+        )
+    }
 }

--- a/recompose-test/src/main/resources/styleattributes.xml
+++ b/recompose-test/src/main/resources/styleattributes.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TextView
+        xmlns:android="http://schemas.android.com/apk/res/android"
+        android:layout_height="50dp"
+        android:layout_width="200dp"
+        android:background="?selectableItemBackground" />


### PR DESCRIPTION
Issue: https://github.com/pocmo/recompose/issues/98 Add support for style attribute

### Context

The plugin cannot handle a layout with a style attribute (like `?selectableItemBackground`)

### Changes

Convert attributes like `?selectableItemBackground` in `imageAttribute(selectableItemBackground)`